### PR TITLE
Force AWS usage of creds file

### DIFF
--- a/internal/pkg/aws/aws.go
+++ b/internal/pkg/aws/aws.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"gopkg.in/ini.v1"
@@ -17,8 +18,14 @@ import (
 	"github.com/spf13/afero"
 )
 
+const (
+	tokenValidationRegex string = "^[0-9]+$"
+)
+
 var (
 	appFs = afero.NewOsFs()
+
+	tokenValidationRegexComplied = regexp.MustCompilePOSIX(tokenValidationRegex)
 )
 
 //Credentials represents the set of attributes used to authenticate to AWS with a short lived session
@@ -135,6 +142,9 @@ func openFile(path string) ([]byte, error) {
 
 func validateToken(token string) error {
 	if len(token) <= 5 {
+		return ErrInvalidToken
+	}
+	if !tokenValidationRegexComplied.MatchString(token) {
 		return ErrInvalidToken
 	}
 

--- a/internal/pkg/aws/aws.go
+++ b/internal/pkg/aws/aws.go
@@ -8,6 +8,8 @@ import (
 
 	"gopkg.in/ini.v1"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -58,7 +60,9 @@ func GenerateSTSCredentials(profile string, tokenCode string) (*Credentials, err
 	}
 
 	awsSession := session.Must(session.NewSessionWithOptions(session.Options{
-		Profile: profile,
+		Config: aws.Config{
+			Credentials: credentials.NewSharedCredentials(path, profile),
+		},
 	}))
 
 	iamInstance := iam.New(awsSession)

--- a/internal/pkg/aws/aws_test.go
+++ b/internal/pkg/aws/aws_test.go
@@ -235,6 +235,20 @@ func Test_validateToken(t *testing.T) {
 			true,
 		},
 		{
+			"Invalid/NotNumbers",
+			args{
+				token: "23ss21",
+			},
+			true,
+		},
+		{
+			"Invalid/NotNumbersLong",
+			args{
+				token: "5364f'[73",
+			},
+			true,
+		},
+		{
 			"Valid/Token",
 			args{
 				token: "1234532",


### PR DESCRIPTION
- Fixed an issue where AWS session was using STS env variables instead of local creds file
- Added further tests to token validation 